### PR TITLE
Add missing variable declaration

### DIFF
--- a/1.4 - Textures/Shader.cs
+++ b/1.4 - Textures/Shader.cs
@@ -41,7 +41,7 @@ namespace LearnOpenGL_TK
 
             GL.LinkProgram(Handle);
 
-            GL.GetProgramInfoLog(Handle);
+            string infoLogLink = GL.GetProgramInfoLog(Handle);
             if (infoLogLink != System.String.Empty)
                 System.Console.WriteLine(infoLogLink);
 


### PR DESCRIPTION
Variable `infoLogLink` does not appear to be declared in the file.