### PR TITLE
Found some more errors

### DIFF
--- a/1.4 - Textures/Game.cs
+++ b/1.4 - Textures/Game.cs
@@ -63,7 +63,7 @@ namespace LearnOpenGL_TK
             VertexArrayObject = GL.GenVertexArray();
             GL.BindVertexArray(VertexArrayObject);
 
-            GL.BindBuffer(BufferTarget.ArrayBuffer, VertexArrayObject);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, VertexBufferObject);
             GL.BindBuffer(BufferTarget.ElementArrayBuffer, ElementBufferObject);
 
             //Because there's now 5 floats between the start of the first vertex and the start of the second,

--- a/1.4 - Textures/Shader.cs
+++ b/1.4 - Textures/Shader.cs
@@ -30,7 +30,7 @@ namespace LearnOpenGL_TK
             GL.ShaderSource(FragmentShader, FragmentShaderSource);
             GL.CompileShader(FragmentShader);
 
-            string infoLogFrag = GL.GetShaderInfoLog(VertexShader);
+            string infoLogFrag = GL.GetShaderInfoLog(FragmentShader);
             if (infoLogFrag != System.String.Empty)
                 System.Console.WriteLine(infoLogFrag);
 
@@ -41,7 +41,7 @@ namespace LearnOpenGL_TK
 
             GL.LinkProgram(Handle);
 
-            GL.GetProgramInfoLog(Handle);
+            string infoLogLink = GL.GetProgramInfoLog(Handle);
             if (infoLogLink != System.String.Empty)
                 System.Console.WriteLine(infoLogLink);
 


### PR DESCRIPTION
I also get some graphical errors with the texture loading with `SixLabors.ImageSharp` on Linux/Mono. I tried just changing the `Texture.cs` class to use `System.Drawing` to load the texture instead and the errors disappeared. Perhaps that would be better to use in the tutorial since it is also one dependency less.