### PR TITLE
Fix wrong namespace in GLControl

### DIFF
--- a/GLControl/MainForm.cs
+++ b/GLControl/MainForm.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
-using LearnOpenGL_TK.Common;
+using LearnOpenTK.Common;
 using OpenTK;
 using OpenTK.Graphics.OpenGL4;
 


### PR DESCRIPTION
GLControl still used the old namespace LearnOpenGL_TK instead of the new LearnOpenTK