### PR TITLE
Fixed a small clamping issue with the camera fov

### DIFF
--- a/Common/Camera.cs
+++ b/Common/Camera.cs
@@ -81,7 +81,7 @@ namespace LearnOpenTK.Common
             get => MathHelper.RadiansToDegrees(_fov);
             set
             {
-                var angle = MathHelper.Clamp(value, 1f, 45f);
+                var angle = MathHelper.Clamp(value, 1f, 90f);
                 _fov = MathHelper.DegreesToRadians(angle);
             }
         }


### PR DESCRIPTION
The default value stored in _fov is 'PI/2 rad' or 90°, which is greater than the maximum clamping value of 45°