### PR TITLE
Minor upgrades to 4.8.2 and .NET 8.0

### DIFF
--- a/Chapter1/1-CreatingAWindow/1-CreatingAWindow.csproj
+++ b/Chapter1/1-CreatingAWindow/1-CreatingAWindow.csproj
@@ -3,10 +3,10 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 </Project>

--- a/Chapter1/1-CreatingAWindow/Program.cs
+++ b/Chapter1/1-CreatingAWindow/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Creating a Window",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter1/2-HelloTriangle/2-HelloTriangle.csproj
+++ b/Chapter1/2-HelloTriangle/2-HelloTriangle.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter1/2-HelloTriangle/Program.cs
+++ b/Chapter1/2-HelloTriangle/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Creating a Window",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter1/3-ElementBufferObjects/3-ElementBufferObjects.csproj
+++ b/Chapter1/3-ElementBufferObjects/3-ElementBufferObjects.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter1/3-ElementBufferObjects/Program.cs
+++ b/Chapter1/3-ElementBufferObjects/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Element Buffer Objects",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter1/4-Shaders-InsAndOuts/4-Shaders-InsAndOuts.csproj
+++ b/Chapter1/4-Shaders-InsAndOuts/4-Shaders-InsAndOuts.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter1/4-Shaders-InsAndOuts/Program.cs
+++ b/Chapter1/4-Shaders-InsAndOuts/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Shaders In and Outs!",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter1/4-Shaders-MoreAttributes/4-Shaders-MoreAttributes.csproj
+++ b/Chapter1/4-Shaders-MoreAttributes/4-Shaders-MoreAttributes.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter1/4-Shaders-MoreAttributes/Program.cs
+++ b/Chapter1/4-Shaders-MoreAttributes/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Shaders More Attributes!",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter1/4-Shaders-Uniforms/4-Shaders-Uniforms.csproj
+++ b/Chapter1/4-Shaders-Uniforms/4-Shaders-Uniforms.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter1/4-Shaders-Uniforms/Program.cs
+++ b/Chapter1/4-Shaders-Uniforms/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Shaders Uniforms!",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter1/5-Textures/5-Textures.csproj
+++ b/Chapter1/5-Textures/5-Textures.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter1/5-Textures/Program.cs
+++ b/Chapter1/5-Textures/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Textures",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter1/6-MultipleTextures/6-MultipleTextures.csproj
+++ b/Chapter1/6-MultipleTextures/6-MultipleTextures.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter1/6-MultipleTextures/Program.cs
+++ b/Chapter1/6-MultipleTextures/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Multiple Textures",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter1/7-Transformations/7-Transformations.csproj
+++ b/Chapter1/7-Transformations/7-Transformations.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter1/7-Transformations/Program.cs
+++ b/Chapter1/7-Transformations/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Transformations",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter1/8-CoordinatesSystems/8-CoordinatesSystems.csproj
+++ b/Chapter1/8-CoordinatesSystems/8-CoordinatesSystems.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter1/8-CoordinatesSystems/Program.cs
+++ b/Chapter1/8-CoordinatesSystems/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Coordinates Systems",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter1/9-Camera/9-Camera.csproj
+++ b/Chapter1/9-Camera/9-Camera.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter1/9-Camera/Program.cs
+++ b/Chapter1/9-Camera/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Camera",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter2/1-Colors/1-Colors.csproj
+++ b/Chapter2/1-Colors/1-Colors.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter2/1-Colors/Program.cs
+++ b/Chapter2/1-Colors/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Colors",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter2/2-BasicLighting/2-BasicLighting.csproj
+++ b/Chapter2/2-BasicLighting/2-BasicLighting.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter2/2-BasicLighting/Program.cs
+++ b/Chapter2/2-BasicLighting/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Basic lighting",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter2/3-Materials/3-Materials.csproj
+++ b/Chapter2/3-Materials/3-Materials.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter2/3-Materials/Program.cs
+++ b/Chapter2/3-Materials/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Materials",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter2/4-LightingMaps/4-LightingMaps.csproj
+++ b/Chapter2/4-LightingMaps/4-LightingMaps.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter2/4-LightingMaps/Program.cs
+++ b/Chapter2/4-LightingMaps/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Lighting maps",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter2/5-LightCasters-DirectionalLights/5-LightCasters-DirectionalLights.csproj
+++ b/Chapter2/5-LightCasters-DirectionalLights/5-LightCasters-DirectionalLights.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter2/5-LightCasters-DirectionalLights/Program.cs
+++ b/Chapter2/5-LightCasters-DirectionalLights/Program.cs
@@ -9,7 +9,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new OpenTK.Mathematics.Vector2i(800, 600),
+                ClientSize = new OpenTK.Mathematics.Vector2i(800, 600),
                 Title = "LearnOpenTK - Light caster - directional",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter2/5-LightCasters-PointLights/5-LightCasters-PointLights.csproj
+++ b/Chapter2/5-LightCasters-PointLights/5-LightCasters-PointLights.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter2/5-LightCasters-PointLights/Program.cs
+++ b/Chapter2/5-LightCasters-PointLights/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Light casters - point lights",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter2/5-LightCasters-Spotlight/5-LightCasters-Spotlight.csproj
+++ b/Chapter2/5-LightCasters-Spotlight/5-LightCasters-Spotlight.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter2/5-LightCasters-Spotlight/Program.cs
+++ b/Chapter2/5-LightCasters-Spotlight/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Light casters - spotlight",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Chapter2/6-MultipleLights/6-MultipleLights.csproj
+++ b/Chapter2/6-MultipleLights/6-MultipleLights.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LearnOpenTK</RootNamespace>
     <AssemblyName>LearnOpenTK</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chapter2/6-MultipleLights/Program.cs
+++ b/Chapter2/6-MultipleLights/Program.cs
@@ -10,7 +10,7 @@ namespace LearnOpenTK
         {
             var nativeWindowSettings = new NativeWindowSettings()
             {
-                Size = new Vector2i(800, 600),
+                ClientSize = new Vector2i(800, 600),
                 Title = "LearnOpenTK - Multiple lights",
                 // This is needed to run on macos
                 Flags = ContextFlags.ForwardCompatible,

--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -2,11 +2,11 @@
   <PropertyGroup>
     <RootNamespace>LearnOpenTK.Common</RootNamespace>
     <AssemblyName>LearnOpenTK.Common</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTK" Version="4.7.4" />
+    <PackageReference Include="OpenTK" Version="4.8.2" />
     <PackageReference Include="StbImageSharp" Version="2.27.11" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Includes these minor tweaks:

1. Upgrades all the projects to .NET 8.0
2. Leverages the 4.8.2 release of OpenTK
3. Updates the deprecated use of .Size on NativeWindowSettings to .ClientSize



